### PR TITLE
Migrate editing to Zotero

### DIFF
--- a/fern_fossils.bib
+++ b/fern_fossils.bib
@@ -595,7 +595,7 @@ author = {Ren, Wen-xiu and Wu, Guang-tao and Han, Lei and Hua, Yi-fan and Sun, B
 doi = {10.1080/08912963.2021.2022135},
 journal = {Historical Biology},
 pages = {1--8},
-title = {{New species of fossil Dryopterites from the Lower Cretaceous in the Zhongkouzi Basin, Beishan area, Northwest China, and its geological significance}},
+title = {{New species of fossil \textit{Dryopterites} from the Lower Cretaceous in the Zhongkouzi Basin, Beishan area, Northwest China, and its geological significance}},
 year = {2022}
 }
 

--- a/fern_fossils.bib
+++ b/fern_fossils.bib
@@ -1,699 +1,815 @@
+
 @article{Axsmith_etal-2001,
-author = {Axsmith, Brian J and Kings, Michael and Taylor, Thomas N.},
-journal = {American Journal of Botany},
-number = {9},
-pages = {1558--1567},
-title = {{A filmy fern from the Upper Triassic of North Carolina (USA)}},
-volume = {88},
-year = {2001}
+  title = {A filmy fern from the Upper Triassic of North Carolina (USA)},
+  author = {Axsmith, Brian J and Kings, Michael and Taylor, Thomas N.},
+  date = {2001},
+  journaltitle = {American Journal of Botany},
+  volume = {88},
+  number = {9},
+  pages = {1558--1567},
+  doi = {10.2307/3558399}
 }
+
 @article{Barrington-1983,
-author = {Barrington, David S},
-journal = {American Journal of Botany},
-number = {8},
-pages = {1118--1124},
-title = {{\textit{Cibotium oregonense}: An Eocene tree-fern stem and petioles with internal structure}},
-volume = {70},
-year = {1983}
+  title = {\emph{Cibotium oregonense}: An Eocene tree-fern stem and petioles with internal structure},
+  author = {Barrington, David S},
+  date = {1983},
+  journaltitle = {American Journal of Botany},
+  volume = {70},
+  number = {8},
+  pages = {1118--1124},
+  doi = {10.1002/j.1537-2197.1983.tb12460.x}
 }
+
 @article{Bateman-1991,
-author = {Bateman, Richard M.},
-journal = {Palaeontographica Abt. B},
-pages = {1--59},
-title = {{Palaeobiological and phylogenetic implications of anatomically-preserved \textit{Archaeocalamites} from the Dinantian of Oxroad Bay and Loch Humphrey Burn, Southern Scotland}},
-volume = {223},
-year = {1991}
+  title = {Palaeobiological and phylogenetic implications of anatomically-preserved {\emph{Archaeocalamites}} from the Dinantian of Oxroad Bay and Loch Humphrey Burn, Southern Scotland},
+  author = {Bateman, Richard M.},
+  date = {1991},
+  journaltitle = {Palaeontographica Abt. B},
+  volume = {223},
+  pages = {1--59}
 }
+
 @article{Batten_etal-1998,
-author = {Batten, David J. and Collinson, Margaret E. and Brain, Anthony P. R.},
-doi = {10.2307/2446543},
-journal = {American Journal of Botany},
-number = {5},
-pages = {724--735},
-title = {{Ultrastructural interpretation of the Late Cretaceous megaspore \textit{Glomerisporites pupus} and its associated microspores}},
-volume = {85},
-year = {1998}
+  title = {Ultrastructural interpretation of the Late Cretaceous megaspore {{{\emph{Glomerisporites pupus}}}} and its associated microspores},
+  author = {Batten, David J. and Collinson, Margaret E. and Brain, Anthony P. R.},
+  date = {1998},
+  journaltitle = {American Journal of Botany},
+  volume = {85},
+  number = {5},
+  pages = {724--735},
+  doi = {10.2307/2446543}
 }
+
 @article{BertoliCunha_etal-2008,
-author = {Bertoli-Cunha, Michele and Dutra, T{\^{a}}nia L. and Cardoso, N},
-journal = {Journal of Geoscience},
-number = {1},
-pages = {1--13},
-title = {{Uma Dicksoniaceae f{\'{e}}rtil no Eoceno da Ilha King George, Pen{\'{i}}nsula Ant{\'{a}}rtica}},
-volume = {4},
-year = {2008}
+  title = {Uma Dicksoniaceae fértil no Eoceno da Ilha King George, Península Antártica},
+  author = {Bertoli-Cunha, Michele and Dutra, Tânia L. and Cardoso, N},
+  date = {2008},
+  journaltitle = {Journal of Geoscience},
+  volume = {4},
+  number = {1},
+  pages = {1--13}
 }
+
 @book{Bolchotinova_1953,
-author = {Bolchotinova, A.},
-pages = {184},
-publisher = {издательство академии наук ссср},
-title = {{Спорово-пыльцевая характеристика меловых отложений центральных областей СССР}},
-year = {1953}
+  title = {Спорово-пыльцевая характеристика меловых отложений центральных областей СССР},
+  author = {Bolchotinova, A.},
+  date = {1953},
+  pages = {184},
+  publisher = {издательство академии наук ссср}
 }
+
 @article{Bonde_Kumaran-2002,
-author = {Bonde, S D and Kumaran, K P N},
-journal = {Review of Palaeobotany and Palynology},
-pages = {285--299},
-title = {{A permineralized species of mangrove fern \textit{Acrostichum} L. from Deccan Intertrappean beds of India}},
-volume = {120},
-year = {2002}
+  title = {A permineralized species of mangrove fern {\emph{Acrostichum}} L. from Deccan Intertrappean beds of India},
+  author = {Bonde, S D and Kumaran, K P N},
+  date = {2002},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {120},
+  pages = {285--299},
+  doi = {10.1016/S0034-6667(02)00081-7}
 }
+
 @article{Brown-1975,
-author = {Brown, John Thomas},
-journal = {American Journal of Botany},
-number = {4},
-pages = {410--415},
-title = {{\textit{Equisetum clarnoi}, a new species based on petrifactions from the Eocene of Oregon}},
-volume = {62},
-year = {1975}
+  title = {\emph{Equisetum clarnoi}, a new species based on petrifactions from the Eocene of Oregon},
+  author = {Brown, John Thomas},
+  date = {1975},
+  journaltitle = {American Journal of Botany},
+  volume = {62},
+  number = {4},
+  pages = {410--415},
+  doi = {10.1002/j.1537-2197.1975.tb14064.x}
 }
+
 @article{Cantrill-1998,
-author = {Cantrill, David J.},
-doi = {10.1080/03115519808619203},
-journal = {Alcheringa},
-number = {3},
-pages = {241--258},
-title = {{Early Cretaceous fern foliage from President Head, Snow Island, Antarctica}},
-volume = {22},
-year = {1998}
-}
-@article{Chen_etal-1997,
-author = {Chen, Fen and Deng, Sheghui and Sun, Keqin},
-journal = {Paleobotanist},
-number = {3},
-pages = {117--133},
-title = {{Early Cretaceous \textit{Athyrium} Roth from Northeastern China}},
-volume = {46},
-year = {1997}
-}
-@book{Chlonova-1960,
-address = {Novosibirsk},
-author = {Chlonova, A. F.},
-publisher = {СИБИРСКОГО ОТДЕЛЕНИЯ АН СССР},
-title = {{ВИДОВОЙ СОСТАВ ПЫЛЬЦЫ И СПОР В ОТЛОЖЕНИЯХ ВЕРХНЕГО МЕЛА ЧУЛЫМО-ЕНИСЕЙСКОЙ ВПАДИНЫ}},
-year = {1960}
-}
-@article{Conran_etal-2010,
-author = {Conran, John G and Kaulfuss, Uwe and Bannister, Jennifer M and Mildenhall, Dallas C and Lee, Daphne E},
-journal = {Review of Palaeobotany and Palynology},
-pages = {84--94},
-publisher = {Elsevier B.V.},
-title = {{Review of Palaeobotany and Palynology \textit{Davallia} (Polypodiales: Davalliaceae) macrofossils from Early Miocene Otago (New Zealand) with in situ spores}},
-volume = {162},
-year = {2010}
-}
-@phdthesis{Crabtree-1987,
-author = {Crabtree, David},
-pages = {336},
-school = {University of Montana},
-title = {{The early Campanian flora of the Two Medicine Formation, northcentral Montana}},
-type = {Dissertation, Doctor of Philosophy (PhD)},
-year = {1987}
-}
-@article{Edwards_etal-1992,
-author = {Edwards, D and Davies, K L and Axe, L},
-journal = {Nature},
-pages = {683--685},
-title = {{A vascular conducting strand in the early land plant \textit{Cooksonia}}},
-volume = {357},
-year = {1992}
-}
-@article{Falaschi_etal-2009,
-author = {Falaschi, Paula and Zamunier, Alba B. and Foix, Nicol{\'{a}}s},
-journal = {Ameghiniana},
-number = {2},
-pages = {263--272},
-title = {{Una nueva Equisetaceae f{\'{e}}rtil de la Formaci{\'{o}}n La Matilde, Jur{\'{a}}sico Medio, Argentina}},
-volume = {46},
-year = {2009}
-}
-@article{Herendeen1998,
-author = {Herendeen, Patrick S and Skog, Judith E},
-journal = {International Journal of Plant Sciences},
-pages = {870--879},
-title = {{\textit{Gleichenia chaloneri} - A new fossil fern from the Lower Cretaceous (Albian) of England}},
-volume = {159},
-year = {1998}
-}
-@article{Massini_etal-2006,
-author = {Garc{\'{i}}a-Massinni, J.L. and Jacobs, Bonnie Fine and Pan, A. and Tabor, N. and Kappelman, J.},
-journal = {International Journal of Plant Sciences},
-number = {4},
-pages = {909--918},
-title = {{The occurrence of the fern \textit{Acrostichum} in Oligocene volcanic strata of the Northwestern Ethiopian Plateau}},
-volume = {167},
-year = {2006}
-}
-@article{Graham_Jarzen-1969,
-author = {Graham, Alan and Jarzen, David M},
-journal = {Annals of the Missouri Botanical Garden},
-number = {3},
-pages = {308--357},
-title = {{Studies in neotropical paleobotany. I. The Oligocene communities of Puerto Rico}},
-volume = {56},
-year = {1969}
-}
-@book{Hao_Xue-2013b,
-address = {Beijing},
-author = {Hao, Shougang and Xue, Jinzhuang},
-pages = {363},
-publisher = {Science Press},
-title = {{The Early Devonian Posongchong Flora of Yunnan - A contribution to an understanding of the evolution and early diversification of vascular plants}},
-year = {2013}
-}
-@book{Harris-1961,
-address = {London},
-author = {Harris, Thomas Maxwell},
-pages = {205},
-publisher = {British Museum (Natural History)},
-title = {{The Yorkshire Jurassic Flora. I. Thallophyta-Pteridophyta}},
-year = {1961}
-}
-@article{HernandezCastillo_etal-2006,
-author = {Hernandez-Castillo, Genaro R and Stockey, Ruth A and Rothwell, Gar W},
-journal = {International Journal of Plant Sciences},
-keywords = {schizaeaceae},
-number = {3},
-pages = {665--674},
-title = {{\textit{Anemia quatsinoensis} sp. nov. (Schizaceae), a permineralized fern from the Lower Cretaceous of Vancouver Island}},
-volume = {167},
-year = {2006}
-}
-@article{Herrera_etal-2017,
-author = {Herrera, Fabiany and Moran, Robbin C and Shi, Gongle and Ichinnorov, Niiden and Takahashi, Masamichi and Crane, Peter R and Herendeen, Patrick S},
-journal = {American Journal of Botany},
-number = {9},
-pages = {1370--1381},
-title = {{An exquisitely preserved filmy fern (Hymenophyllaceae) from the Early Cretaceous of Mongolia}},
-volume = {104},
-year = {2017}
-}
-@article{Krafit_Stockey-2008,
-author = {Karafit, Steven J and Stockey, Ruth A},
-journal = {Review of Palaeobotany and Palynology},
-pages = {163--173},
-title = {{\textit{Paralygodium meckertii} sp. nov. (Schizaeaceae) from the Upper Cretaceous (Coniacian) of Vancouver Island, British Columbia, Canada}},
-volume = {149},
-year = {2008}
-}
-@article{Klavins_etal-2004,
-author = {Klavins, Sharon D. and Taylor, Thomas N. and Taylor, Edith L.},
-journal = {Journal of Paleontology},
-number = {1},
-pages = {211--217},
-title = {{Matoniaceous ferns (Gleicheniales) from the Middle Triassic}},
-volume = {78},
-year = {2004}
-}
-@article{Kvacek-2001,
-author = {Kvacek, Zlatko},
-journal = {Feddes Repertorium},
-pages = {159--177},
-title = {{A new fossil species of \textit{Polypodium} (Polypodiaceae) from the Oligocene of northern Bohemia (Czech Republic)}},
-volume = {112},
-year = {2001}
-}
-@article{Kvacek_Teo-2020,
-author = {Kvacek, Zlatko and Teodoridis, Vasilis},
-journal = {Neues Jahrbuch f{\"{u}}r Geologie und Pal{\"{a}}ontologie, Abhandlungen},
-pages = {9--16},
-title = {{A new Oligocene fern of Dryopteridaceae from the Cesk{\'{e}} stredohori Mts (Czech Republic)}},
-volume = {295},
-year = {2020}
-}
-@article{Loriga_etal-2014,
-author = {L{\'{o}}riga, Josmaily and Schmidt, Alexander R and Moran, Robbin and Feldberg, Kathrin and Schneider, Harald and Heinrichs, Jochen},
-journal = {American Journal of Botany},
-number = {9},
-pages = {1466--1475},
-title = {{The first fossil of a bolbitidoid fern belongs to the early-divergent lineages of \textit{Elaphoglossum} (Dryopteridaceae)}},
-volume = {101},
-year = {2014}
-}
-@article{Nagalingum_Cantrill-2006,
-author = {Nagalingum, Nathalie S and Cantrill, David J},
-journal = {Review of Palaeobotany and Palynology},
-pages = {73--93},
-title = {{Early Cretaceous Gleicheniaceae and Matoniaceae (Gleicheniales) from Alexander Island, Antarctica}},
-volume = {138},
-year = {2006}
-}
-@article{Naugolnykh_etal-2016,
-author = {Naugolnykh, Serge V and Wang, Li and Han, Meng and Hua, Jian},
-issn = {1618-0860},
-journal = {Journal of Plant Research},
-pages = {3--12},
-title = {{A new find of the fossil \textit{Cyclosorus} from the Eocene of South China and its paleoclimatic implication}},
-volume = {129},
-year = {2016}
-}
-@article{Naugolnykh_etal-2020,
-author = {Naugolnykh, Sergey V and Tu, Ming and Liu, Xiao-yan and Jin, Jian-hua},
-issn = {1871-174X},
-journal = {Palaeoworld},
-pages = {606--616},
-title = {{A new species of \textit{Lygodium} (Schizaeaceae) from the Buxin Formation (middle Paleocene), Sanshui Basin, South China}},
-volume = {29},
-year = {2020}
-}
-@article{Nishida-1989,
-author = {Nishida, Harufumi},
-journal = {Botanical Magazine Tokyo},
-pages = {255--282},
-title = {{Structure and affinities of the petrified plants from the Cretaceous of Japan and Saghalien, V. Tree fern stems from Hokkaido, \textit{Paracyathocaulis ogurae} gen. et comb. nov. and \textit{Cyathocaulis yezopteroides} sp. nov.}},
-volume = {102},
-year = {1989}
-}
-
-@article{Ogura-1927b,
-author = {Ogura, Y},
-journal = {Journal of the Faculty of Science, Imperial University of Tokyo},
-pages = {351--380},
-title = {{On the structure and affinities of some fossil tree-ferns from Japan}},
-volume = {1},
-year = {1927}
-}
-
-@article{Ogura-1933,
-author = {Ogura, Yudzuru},
-journal = {The Botanical Magazine},
-number = {563},
-pages = {748--754},
-title = {{On the structure of a fossil fern stem of \textit{Cibotium}-type from the Upper Cretaceous of Iwate}},
-volume = {48},
-year = {1933}
-}
-@article{Pinson_etal-2018,
-author = {Pinson, Jerald B. and Manchester, Steven R. and Sessa, Emily B.},
-journal = {International Journal of Plant Sciences},
-number = {8},
-pages = {635--639},
-title = {{\textit{Culcita remberi} sp. nov., an understory fern of Cyatheales from the Miocene of northern Idaho}},
-volume = {179},
-year = {2018}
-}
-@article{Rees_Cleal-2004,
-author = {Rees, P.M. and Cleal, C.J.},
-journal = {Special Papers in Palaentology},
-pages = {5--90},
-title = {{Lower Jurassic floras from Hope Bay and Botany Bay, Antarctica}},
-volume = {72},
-year = {2004}
-}
-@article{Regalado_etal-2017b,
-author = {Regalado, Ledis and Schmidt, Alexander R and Appelhans, Marc S and Ilsemann, Bork},
-journal = {Scientific Reports},
-number = {14615},
-pages = {1--9},
-title = {{A fossil species of the enigmatic early polypod fern genus \textit{Cystodium} (Cystodiaceae) in Cretaceous amber from Myanmar}},
-volume = {7},
-year = {2017}
-}
-@article{Regalado_etal-2018,
-author = {Regalado, Ledis and Schmidt, Alexander R and Krings, Michael and Bechteler, Julia and Schneider, Harald and Heinrichs, Jochen},
-journal = {Plant Systematics and Evolution},
-number = {1},
-pages = {1--13},
-title = {{Fossil evidence of eupolypod ferns in the mid-Cretaceous of Myanmar}},
-volume = {304},
-year = {2018}
-}
-@article{Regalado_etal-2017,
-author = {Regalado, Ledis and Schmidt, Alexander R and M{\"{u}}ller, Patrick and Kobbert, Max J and Schneider, Harald and Heinrichs, Jochen},
-journal = {Cretaceous Research},
-pages = {8--12},
-title = {{The first fossil of Lindsaeaceae (Polypodiales) from the Cretaceous amber forest of Myanmar}},
-volume = {72},
-year = {2017}
-}
-@article{Regalado_etal-2019,
-author = {Regalado, Ledis and Schmidt, Alexander R and M{\"{u}}ller, Patrick and Niedermeier, Lisa and Krings, Michael and Schneider, Harald},
-journal = {Journal of Systematics and Evolution},
-number = {4},
-pages = {329--338},
-title = {{\textit{Heinrichsia cheilanthoides} gen. et sp. nov., a fossil fern in the family Pteridaceae (Polypodiales) from the Cretaceous amber forests of Myanmar}},
-volume = {57},
-year = {2019}
-}
-@article{Rothwell_Stockey-1991,
-author = {Rothwell, Gar W. and Stockey, Ruth},
-journal = {Review of Palaeobotany and Palynology},
-pages = {113--124},
-title = {{\textit{Onoclea sensibilis} in the Paleocene of North America, a dramatic example of structural and ecological stasis}},
-volume = {70},
-year = {1991}
-}
-@article{Schneider_etal-2016,
-author = {Schneider, Harald and Schmidt, Alexander R and Heinrichs, Jochen},
-journal = {Perspectives in Plant Ecology, Evolution and Systematics},
-pages = {70--78},
-title = {{Burmese amber fossils bridge the gap in the Cretaceous record of polypod ferns}},
-volume = {18},
-year = {2016}
-}
-@article{Schnneider_etal-2015,
-author = {Schneider, Harald and Schmidt, Alexander R and Nascimbene, Paul C and Heinrichs, Jochen},
-journal = {Organisms Diversity & Evolution},
-pages = {277--283},
-title = {{A new Dominican amber fossil of the derived fern genus \textit{Pleopeltis} confirms generic stasis in the epiphytic fern diversity of the West Indies}},
-volume = {15},
-year = {2015}
-}
-@article{Skog-1976,
-author = {Skog, Judith E},
-journal = {American Fern Journal},
-number = {1},
-pages = {8--14},
-title = {{\textit{Loxsomopteris anasilla}, a new fossil fern rhizome from the Cretaceous of Maryland}},
-volume = {66},
-year = {1976}
-}
-@article{Smith_etal-2006,
-author = {Smith, Selena Y and Stockey, Ruth A and Nishida, Harufumi and Rothwell, Gar W},
-journal = {International Journal of Plant Sciences},
-pages = {711--719},
-title = {{\textit{Trawetssia princetonensis} gen. et sp. nov. (Blechnaceae): a permineralized fern from the Middle Eocene Princeton Chert}},
-volume = {167},
-year = {2006}
-}
-
-@article{Stockey_etal-1999,
-author = {Stockey, Ruth A and Nishida, Harufumi and Rothwell, Gar W},
-journal = {International Journal of Plant Sciences},
-pages = {1047--1055},
-title = {{Permineralized ferns from the Middle Eocene Princeton Chert. I. \textit{Makotopteris princetonensis} gen. et sp. nov. (Athyriaceae)}},
-volume = {160},
-year = {1999}
-}
-
-@article{Taylor-1967,
-author = {Taylor, Thomas N},
-journal = {Palaeontology},
-pages = {43--46},
-title = {{On the structure and phylogenetic relationships of the fern \textit{Radstockia} Kidston}},
-volume = {10},
-year = {1967}
-}
-@article{Tian_etal-2018,
-author = {Tian, Ning and Wang, Yong-dong and Zhang, Wu and Zheng, Shao-lin and Zhu, Zhi-peng},
-journal = {Palaeobiodiversity and Palaeoenvironments},
-pages = {165--176},
-title = {{Permineralized osmundaceous and gleicheniaceous ferns from the Jurassic of Inner Mongolia, NE China}},
-volume = {98},
-year = {2018}
-}
-@article{Tidwell_etal-1989,
-author = {Tidwell, William D and Nishida, Harufumi and Webster, Neri},
-journal = {Papers and Proceedings of the Royal Society of Tasmania},
-pages = {15--25},
-title = {{\textit{Oguracaulis banksii} gen. et sp. nov., a mid-Mesozoic tree-fern stem from Tasmania, Australia}},
-volume = {123},
-year = {1989}
-}
-@inproceedings{Upchurch_Mack-1998,
-author = {{Upchurch Jr.}, Garland R and Mack, Greg H.},
-booktitle = {Las Cruces Country II},
-editor = {Mack, Greg H. and Austin, G.S. and Barker, J. M.},
-pages = {209--222},
-publisher = {New Mexico Geological Society Guidebook, 49th Field Conference},
-title = {{Latest Cretaceous leaf megafloras from the Jose Creek Member, McRae Formation of New Mexico}},
-year = {1998}
-}
-@article{vanKonijnenburg-1989,
-author = {{van Konijnenburg-van Cittert}, J. H.A.},
-journal = {Review of Palaeobotany and Palynology},
-pages = {273--301},
-title = {{Dicksoniaceous spores in situ from the Jurassic of Yorshire, England}},
-volume = {61},
-year = {1989}
-}
-@article{Vikulin_etal-1987,
-author = {Vikulin, Sergei V.},
-journal = {Botanicheskii Zhurnal},
-pages = {1--7},
-title = {{A new fossil genus \textit{Prodrynaria} (Polypodiaceae) from the Paleogene flora of Tim (tbe south of the middle Russian upland)}},
-volume = {72},
-year = {1982}
-}
-@article{Xu_etal-2017,
-author = {Xu, Cong-li and Huang, Jian and Su, Tao and Zhang, Xian-chun and Li, Shu-feng and Zhou, Zhe-kun},
-journal = {Palaeoworld},
-number = {3},
-pages = {543--552},
-title = {{The first megafossil record of \textit{Goniophlebium} (Polypodiaceae) from the Middle Miocene of Asia and its paleoecological implications}},
-volume = {26},
-year = {2017}
-}
-@article{Xu_etal-2017b,
-author = {Xu, Kewag and Liao, Wenbo and Jin, Jianhua and Liu, Xiaoyan},
-journal = {Acta Geologica Sinica},
-number = {4},
-pages = {1179--1189},
-title = {{\textit{Asplenium sanshuiense} sp. nov.: The lowest latitude fossil record of the genus}},
-volume = {91},
-year = {2017}
-}
-@article{Yamada_Kato-2002,
-author = {Yamada, Toshihiro and Kato, Masahiro},
-journal = {International Journal of Plant Sciences},
-number = {5},
-pages = {715--723},
-title = {{\textit{Regnellites nagashimae} gen. et sp. nov., the oldest macrofossil of Marsileaecae, from the Upper Jurassic to Lower Cretaceous of Western Japan}},
-volume = {163},
-year = {2002}
-}
-@article{Wang_Pfefferkorn-2008,
-author = {Yang, Shu and Wang, Jun and Pfefferkorn, Hermann W},
-journal = {International Journal of Plant Sciences},
-number = {3},
-pages = {473--482},
-title = {{\textit{Marattia aganzhensis} sp. nov. from the Lower Jurassic Daxigou Formation of Lanzhou, Gansu, China}},
-volume = {169},
-year = {2008}
-}
-@article{Yang_etal-2016,
-author = {Yu, Yang and Xie, San-ping and Devaney, John and Zhang, Si-hang and Chen, Tian-yu},
-journal = {Palaeobiodiversity and Palaeoenvironments},
-pages = {939--949},
-title = {{A new species of \textit{Drynaria} (Polypodiaceae) from the late Miocene of Yunnan, Southwest China and implications on the genus evolution}},
-volume = {100},
-year = {2020}
-}
-@article{Zhaogi_Taylor-1988,
-author = {Zhaoqi, Yao and Taylor, Thomas N},
-journal = {Review of Palaeobotany and Palynology},
-pages = {121--134},
-title = {{On a new Gleicheniaceous fern from the Permian of South China}},
-volume = {54},
-year = {1988}
-}
-
-@article{Christenhusz_etal-2021,
-author = {Christenhusz, Maarten J M and Chase, Mark W and Fay, Michael F and Hidalgo, Oriane and Leitch, Ilia J and Pellicer, Jaume and Viruel, Juan},
-journal = {Annals of Botany},
-pages = {681--695},
-title = {{Biogeography and genome size evolution of the oldest extant vascular plant genus, \textit{Equisetum} (Equisetaceae)}},
-volume = {127},
-year = {2021}
-}
-@article{Dijkstra-1949,
-author = {Dijkstra, S. J.},
-journal = {Mededelingen van de Geologische Stichting, Nieuwe Serie},
-pages = {19--32},
-title = {{Megaspores and some other fossils from the Aachenian (Senonian) in South Limburg, Netherlands}},
-volume = {3},
-year = {1949}
-}
-@article{Elgorriaga_etal-2018,
-author = {Elgorriaga, Andr{\'{e}}s and Escapa, Ignacio H and Rothwell, Gary W. and Tomescu, Alexandru M. F. and C{\'{u}}neo, N. Rub{\'{e}}n},
-journal = {American Journal of Botany},
-pages = {1286--1303},
-title = {{Origin of \textit{Equisetum}: Evolution of horsetails (Equisetales) within the major euphyllophyte clade Sphenopsida}},
-volume = {105},
-year = {2018}
-}
-@article{Lantz_etal-1999,
-author = {Lantz, Trevor C and Rothwell, Gar W and Stockey, Ruth A},
-journal = {Journal of Plant Research},
-pages = {361--381},
-title = {{\textit{Conantiopteris schuchmanii}, gen. et sp. nov., and the role of fossils in resolving the phylogeny of Cyatheaceae s.l.}},
-volume = {112},
-year = {1999}
-}
-@article{Rothwell_etal-2018,
-author = {Rothwell, Gar W and Millay, Michael A and Stockey, Ruth A},
-journal = {American Journal of Botany},
-number = {8},
-pages = {1304--1314},
-title = {{Resolving the overall pattern of marattialean fern phylogeny}},
-volume = {105},
-year = {2018}
-}
-@article{Scott_Galtier-1996,
-author = {Scott, Andrew C and Galtier, Jean},
-journal = {Review of Palaeobotany and Palynology},
-pages = {141--153},
-title = {{A review of the problems in the stratigraphical, palaeoecological and palaeobiogeographical interpretation of Lower Carboniferous (Dinantian) floras from Western Europe}},
-volume = {90},
-year = {1996}
-}
-@article{Stockey_Rothwell-2004,
-author = {Stockey, Ruth A and Rothwell, Gar W},
-journal = {Review of Palaeobotany and Palynology},
-pages = {103--114},
-title = {{Cretaceous tree ferns of western North America: \textit{Rickwoodopteris hirsuta} gen. et sp. nov. (Cyatheaceae s.l.)}},
-volume = {132},
-year = {2004}
-}
-
-@article{Su_etal-2011,
-author = {Su, Tao and Jacques, Fr{\'{e}}d{\'{e}}ric M B and Liu, Yu-sheng Christopher and Xiang, Jianying and Xing, Yaowu and Huang, Yongjiang and Zhou, Zhekun},
-journal = {Review of Palaeobotany and Palynology},
-pages = {132--142},
-title = {{A new \textit{Drynaria} (Polypodiaceae) from the Upper Pliocene of Southwest China}},
-volume = {164},
-year = {2011}
-}
-
-@book{Traverse_Ames-1979,
-author = {Traverse, A. and Ames, H. T.},
-pages = {1--210},
-publisher = {The Pennsylvania State University},
-title = {{Catalog of fossil spores and pollen (Volume 41): Late Cretaceous and Early Tertiary spores and pollen from the USA and the USSR}},
-volume = {41},
-year = {1979}
-}
-
-@book{MacGinitie-1953,
-author = {MacGinitie, H.  D.},
-pages = {1--198},
-publisher = {Carniegie Institution of Washington},
-title = {{Fossil plants of the Florissant Beds, Colorado.}},
-year = {1953}
-}
-
-@article{Piel-1971,
-author = {Piel, K. M.},
-journal = {Canadian Journal of Botany},
-pages = {1885--1920},
-title = {{Palynology of Oligocene sediments from central British Columbia}},
-volume = {49},
-year = {1971}
+  title = {Early Cretaceous fern foliage from President Head, Snow Island, Antarctica},
+  author = {Cantrill, David J.},
+  date = {1998},
+  journaltitle = {Alcheringa},
+  volume = {22},
+  number = {3},
+  pages = {241--258},
+  doi = {10.1080/03115519808619203}
 }
 
 @article{Cesari_PerezLoinaze-2006,
-author = {C{\'{e}}sari, Silvia N and P{\'{e}}rez-Loinaze, Valeria S},
-journal = {Geobios},
-pages = {785--790},
-title = {{A new Carboniferous equisetale from western Gondwana}},
-volume = {39},
-year = {2006}
+  title = {A new Carboniferous equisetale from western Gondwana},
+  author = {Césari, Silvia N and Pérez-Loinaze, Valeria S},
+  date = {2006},
+  journaltitle = {Geobios},
+  volume = {39},
+  pages = {785--790},
+  doi = {10.1016/j.geobios.2006.01.001}
 }
 
-@article{Ren_etal-2022,
-author = {Ren, Wen-xiu and Wu, Guang-tao and Han, Lei and Hua, Yi-fan and Sun, Bai-nian},
-doi = {10.1080/08912963.2021.2022135},
-journal = {Historical Biology},
-pages = {1--8},
-title = {{New species of fossil \textit{Dryopterites} from the Lower Cretaceous in the Zhongkouzi Basin, Beishan area, Northwest China, and its geological significance}},
-year = {2022}
+@article{Chen_etal-1997,
+  title = {Early Cretaceous {\emph{Athyrium}} Roth from Northeastern China},
+  author = {Chen, Fen and Deng, Sheghui and Sun, Keqin},
+  date = {1997},
+  journaltitle = {Paleobotanist},
+  volume = {46},
+  number = {3},
+  pages = {117--133}
 }
 
-@article{PteridophytePhylogenyGroupI2016,
-  title = {{A community-derived classification for extant lycophytes and ferns}},
-  author = {{Pteridophyte Phylogeny Group I}},
-  date = {2016},
-  journal = {Journal of Systematics and Evolution},
-  volume = {54},
-  number = {6},
-  pages = {563--603}
+@book{Chlonova-1960,
+  title = {ВИДОВОЙ СОСТАВ ПЫЛЬЦЫ И СПОР В ОТЛОЖЕНИЯХ ВЕРХНЕГО МЕЛА ЧУЛЫМО-ЕНИСЕЙСКОЙ ВПАДИНЫ},
+  author = {Chlonova, A. F.},
+  date = {1960},
+  publisher = {СИБИРСКОГО ОТДЕЛЕНИЯ АН СССР},
+  location = {Novosibirsk}
 }
 
-@article{VanUffelen-1991,
-  title={{Fossil Polypodiaceae and their spores}},
-  author={Uffelen, Gerda A},
-  journal={Blumea: Biodiversity, Evolution and Biogeography of Plants},
-  volume={36},
-  number={1},
-  pages={253--272},
-  year={1991}
+@article{Christenhusz_etal-2021,
+  title = {Biogeography and genome size evolution of the oldest extant vascular plant genus, {\emph{Equisetum}} (Equisetaceae)},
+  author = {Christenhusz, Maarten J M and Chase, Mark W and Fay, Michael F and Hidalgo, Oriane and Leitch, Ilia J and Pellicer, Jaume and Viruel, Juan},
+  date = {2021},
+  journaltitle = {Annals of Botany},
+  volume = {127},
+  pages = {681--695},
+  doi = {10.1093/aob/mcab005}
 }
 
-@article{Lupia_etal-2000,
-  title={{Marsileaceae sporocarps and spores from the Late Cretaceous of Georgia, USA}},
-  author={Lupia, R and Schneider, H and Moeser, GM and Pryer, KM and Crane, PR},
-  journal={International Journal of Plant Sciences},
-  volume={161},
-  number={6},
-  pages={975--988},
-  year={2000},
-  publisher={The University of Chicago Press}
+@article{Conran_etal-2010,
+  title = {Review of Palaeobotany and Palynology {\emph{Davallia}} (Polypodiales: Davalliaceae) macrofossils from Early Miocene Otago (New Zealand) with in situ spores},
+  author = {Conran, John G and Kaulfuss, Uwe and Bannister, Jennifer M and Mildenhall, Dallas C and Lee, Daphne E},
+  date = {2010},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {162},
+  pages = {84--94},
+  publisher = {Elsevier B.V.},
+  doi = {10.1016/j.revpalbo.2010.06.001}
+}
+
+@thesis{Crabtree-1987,
+  type = {Dissertation, Doctor of Philosophy (PhD)},
+  title = {The early Campanian flora of the Two Medicine Formation, northcentral Montana},
+  author = {Crabtree, David},
+  date = {1987},
+  pages = {336},
+  institution = {University of Montana}
+}
+
+@article{Dijkstra-1949,
+  title = {Megaspores and some other fossils from the Aachenian (Senonian) in South Limburg, Netherlands},
+  author = {Dijkstra, S. J.},
+  date = {1949},
+  journaltitle = {Mededelingen van de Geologische Stichting, Nieuwe Serie},
+  volume = {3},
+  pages = {19--32}
+}
+
+@article{Edwards_etal-1992,
+  title = {A vascular conducting strand in the early land plant {\emph{Cooksonia}}},
+  author = {Edwards, D and Davies, K L and Axe, L},
+  date = {1992},
+  journaltitle = {Nature},
+  volume = {357},
+  pages = {683--685},
+  doi = {10.1038/357683a0}
+}
+
+@article{Elgorriaga_etal-2018,
+  title = {Origin of {\emph{Equisetum}}: Evolution of horsetails (Equisetales) within the major euphyllophyte clade Sphenopsida},
+  author = {Elgorriaga, Andrés and Escapa, Ignacio H and Rothwell, Gary W. and Tomescu, Alexandru M. F. and Cúneo, N. Rubén},
+  date = {2018},
+  journaltitle = {American Journal of Botany},
+  volume = {105},
+  pages = {1286--1303},
+  doi = {10.1002/ajb2.1125}
+}
+
+@article{Falaschi_etal-2009,
+  title = {Una nueva Equisetaceae fértil de la Formación La Matilde, Jurásico Medio, Argentina},
+  author = {Falaschi, Paula and Zamunier, Alba B. and Foix, Nicolás},
+  date = {2009},
+  journaltitle = {Ameghiniana},
+  volume = {46},
+  number = {2},
+  pages = {263--272}
+}
+
+@article{Graham_Jarzen-1969,
+  title = {Studies in neotropical paleobotany. I. The Oligocene communities of Puerto Rico},
+  author = {Graham, Alan and Jarzen, David M},
+  date = {1969},
+  journaltitle = {Annals of the Missouri Botanical Garden},
+  volume = {56},
+  number = {3},
+  pages = {308--357},
+  doi = {10.2307/2394849}
 }
 
 @article{Graham-1979,
-  title={{\textit{Mortoniodendron} (Tiliaceae) and \textit{Sphaeropteris}/\textit{Trichipteris} (Cyatheaceae) in cenozoic deposits of the Gulf-Caribbean region}},
-  author={Graham, Alan},
-  journal={Annals of the Missouri Botanical Garden},
-  pages={572--576},
-  year={1979},
-  publisher={JSTOR}
+  title = {\emph{Mortoniodendron} (Tiliaceae) and \emph{Sphaeropteris}/\emph{Trichipteris} (Cyatheaceae) in cenozoic deposits of the Gulf-Caribbean region},
+  author = {Graham, Alan},
+  date = {1979},
+  journaltitle = {Annals of the Missouri Botanical Garden},
+  pages = {572--576},
+  publisher = {JSTOR},
+  doi = {10.2307/2398850}
+}
+
+@book{Hao_Xue-2013b,
+  title = {The Early Devonian Posongchong Flora of Yunnan - A contribution to an understanding of the evolution and early diversification of vascular plants},
+  author = {Hao, Shougang and Xue, Jinzhuang},
+  date = {2013},
+  pages = {363},
+  publisher = {Science Press},
+  location = {Beijing}
+}
+
+@book{Harris-1961,
+  title = {The Yorkshire Jurassic Flora. I. Thallophyta-Pteridophyta},
+  author = {Harris, Thomas Maxwell},
+  date = {1961},
+  pages = {205},
+  publisher = {British Museum (Natural History)},
+  location = {London}
+}
+
+@article{Herendeen1998,
+  title = {\emph{Gleichenia chaloneri} - A new fossil fern from the Lower Cretaceous (Albian) of England},
+  author = {Herendeen, Patrick S and Skog, Judith E},
+  date = {1998},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {159},
+  pages = {870--879},
+  doi = {10.1086/297609}
+}
+
+@article{HernandezCastillo_etal-2006,
+  title = {\emph{Anemia quatsinoensis} sp. nov. (Schizaceae), a permineralized fern from the Lower Cretaceous of Vancouver Island},
+  author = {Hernandez-Castillo, Genaro R and Stockey, Ruth A and Rothwell, Gar W},
+  date = {2006},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {167},
+  number = {3},
+  pages = {665--674},
+  doi = {10.1086/502801}
+}
+
+@article{Herrera_etal-2017,
+  title = {An exquisitely preserved filmy fern (Hymenophyllaceae) from the Early Cretaceous of Mongolia},
+  author = {Herrera, Fabiany and Moran, Robbin C and Shi, Gongle and Ichinnorov, Niiden and Takahashi, Masamichi and Crane, Peter R and Herendeen, Patrick S},
+  date = {2017},
+  journaltitle = {American Journal of Botany},
+  volume = {104},
+  number = {9},
+  pages = {1370--1381},
+  doi = {10.3732/ajb.1700246}
+}
+
+@article{Klavins_etal-2004,
+  title = {Matoniaceous ferns (Gleicheniales) from the Middle Triassic},
+  author = {Klavins, Sharon D. and Taylor, Thomas N. and Taylor, Edith L.},
+  date = {2004},
+  journaltitle = {Journal of Paleontology},
+  volume = {78},
+  number = {1},
+  pages = {211--217},
+  doi = {10.1666/0022-3360(2004)078<0211:MFGFTM>2.0.CO;2}
+}
+
+@article{Krafit_Stockey-2008,
+  title = {\emph{Paralygodium meckertii} sp. nov. (Schizaeaceae) from the Upper Cretaceous (Coniacian) of Vancouver Island, British Columbia, Canada},
+  author = {Karafit, Steven J and Stockey, Ruth A},
+  date = {2008},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {149},
+  pages = {163--173},
+  doi = {10.1016/j.revpalbo.2007.11.005}
+}
+
+@article{Kvacek_Teo-2020,
+  title = {A new Oligocene fern of Dryopteridaceae from the Ceské stredohori Mts (Czech Republic)},
+  author = {Kvacek, Zlatko and Teodoridis, Vasilis},
+  date = {2020},
+  journaltitle = {Neues Jahrbuch für Geologie und Paläontologie, Abhandlungen},
+  volume = {295},
+  pages = {9--16},
+  doi = {10.1127/njgpa/2020/0864}
+}
+
+@article{Kvacek-2001,
+  title = {A new fossil species of {\emph{Polypodium}} (Polypodiaceae) from the Oligocene of northern Bohemia (Czech Republic)},
+  author = {Kvacek, Zlatko},
+  date = {2001},
+  journaltitle = {Feddes Repertorium},
+  volume = {112},
+  pages = {159--177},
+  doi = {10.1002/fedr.20011120302}
+}
+
+@article{Lantz_etal-1999,
+  title = {\emph{Conantiopteris schuchmanii}, gen. et sp. nov., and the role of fossils in resolving the phylogeny of Cyatheaceae s.l.},
+  author = {Lantz, Trevor C and Rothwell, Gar W and Stockey, Ruth A},
+  date = {1999},
+  journaltitle = {Journal of Plant Research},
+  volume = {112},
+  pages = {361--381},
+  doi = {10.1007/PL00013890}
 }
 
 @article{Liping_etal-2017,
-  title={{Revision on a fossil species of Late Miocene Polypodiaceae from Lin-cang, Yunnan Province, and its biological significance}},
-  author={Yuan, Liping and Xie, Sanping and Sun, Yu and Liu, Zhiwei and Chen, Jie and Guo, Hu},
-  journal={Geological Bulletin of China},
-  volume={36},
-  number={8},
-  pages={1334--1342},
-  year={2017},
-  publisher={Geological Bulletin of China}
+  title = {Revision on a fossil species of Late Miocene Polypodiaceae from Lin-cang, Yunnan Province, and its biological significance},
+  author = {Yuan, Liping and Xie, Sanping and Sun, Yu and Liu, Zhiwei and Chen, Jie and Guo, Hu},
+  date = {2017},
+  journaltitle = {Geological Bulletin of China},
+  volume = {36},
+  number = {8},
+  pages = {1334--1342},
+  publisher = {Geological Bulletin of China}
 }
 
-@article{Xie_etal-2016,
-  title={{First megafossil record of \textit{Neolepisorus} (Polypodiaceae) from the late Miocene of Yunnan, Southwest China}},
-  author={Xie, Sanping and Li, Binke and Zhang, Sihang and Shao, Yang and Wu, Jingyu and Sun, Bainian},
-  journal={PalZ},
-  volume={90},
-  number={2},
-  pages={413--423},
-  year={2016}
+@article{Loriga_etal-2014,
+  title = {The first fossil of a bolbitidoid fern belongs to the early-divergent lineages of {\emph{Elaphoglossum}} (Dryopteridaceae)},
+  author = {Lóriga, Josmaily and Schmidt, Alexander R and Moran, Robbin and Feldberg, Kathrin and Schneider, Harald and Heinrichs, Jochen},
+  date = {2014},
+  journaltitle = {American Journal of Botany},
+  volume = {101},
+  number = {9},
+  pages = {1466--1475},
+  doi = {10.3732/ajb.1400262}
 }
 
-@article{Zhao2019,
-  title={{Backbone phylogeny of \textit{Lepisorus} (Polypodiaceae) and a novel infrageneric classification based on the total evidence from plastid and morphological data}},
-  author={Zhao, Cun-Feng and Wei, Ran and Zhang, Xian-Chun and Xiang, Qiao-Ping},
-  journal={Cladistics},
-  volume={36},
-  number={3},
-  pages={235--258},
-  year={2020}
+@article{Lupia_etal-2000,
+  title = {Marsileaceae sporocarps and spores from the Late Cretaceous of Georgia, USA},
+  author = {Lupia, R and Schneider, H and Moeser, GM and Pryer, KM and Crane, PR},
+  date = {2000},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {161},
+  number = {6},
+  pages = {975--988},
+  publisher = {The University of Chicago Press},
+  doi = {10.1086/317567}
 }
 
-@article{Poinar_Buckley-2008,
-  title={{\textit{Cretacifilix fungiformis} gen. and sp. nov., an eupolypod fern (Polypodiales) in early Cretaceous Burmese Amber}},
-  author={Poinar Jr., George O. and Buckley, Ron},
-  journal={Journal of the Botanical Research Institute of Texas},
-  pages={1175--1182},
-  year={2008}
+@book{MacGinitie-1953,
+  title = {Fossil plants of the Florissant Beds, Colorado.},
+  author = {MacGinitie, H. D.},
+  date = {1953},
+  pages = {1--198},
+  publisher = {Carniegie Institution of Washington}
+}
+
+@article{Massini_etal-2006,
+  title = {The occurrence of the fern {\emph{Acrostichum}} in Oligocene volcanic strata of the Northwestern Ethiopian Plateau},
+  author = {García-Massinni, J.L. and Jacobs, Bonnie Fine and Pan, A. and Tabor, N. and Kappelman, J.},
+  date = {2006},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {167},
+  number = {4},
+  pages = {909--918},
+  doi = {10.1086/504390}
+}
+
+@article{Nagalingum_Cantrill-2006,
+  title = {Early Cretaceous Gleicheniaceae and Matoniaceae (Gleicheniales) from Alexander Island, Antarctica},
+  author = {Nagalingum, Nathalie S and Cantrill, David J},
+  date = {2006},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {138},
+  pages = {73--93},
+  doi = {10.1016/j.revpalbo.2005.11.001}
+}
+
+@article{Naugolnykh_etal-2016,
+  title = {A new find of the fossil {\emph{Cyclosorus}} from the Eocene of South China and its paleoclimatic implication},
+  author = {Naugolnykh, Serge V and Wang, Li and Han, Meng and Hua, Jian},
+  date = {2016},
+  journaltitle = {Journal of Plant Research},
+  volume = {129},
+  pages = {3--12},
+  doi = {10.1007/s10265-015-0765-0}
+}
+
+@article{Naugolnykh_etal-2020,
+  title = {A new species of {\emph{Lygodium}} (Schizaeaceae) from the Buxin Formation (middle Paleocene), Sanshui Basin, South China},
+  author = {Naugolnykh, Sergey V and Tu, Ming and Liu, Xiao-yan and Jin, Jian-hua},
+  date = {2020},
+  journaltitle = {Palaeoworld},
+  volume = {29},
+  pages = {606--616},
+  doi = {10.1016/j.palwor.2019.07.003}
+}
+
+@article{Nishida-1989,
+  title = {Structure and affinities of the petrified plants from the Cretaceous of Japan and Saghalien, V. Tree fern stems from Hokkaido, {{{\emph{Paracyathocaulis ogurae}}}} gen. et comb. nov. and {{{\emph{Cyathocaulis yezopteroides}}}} sp. nov.},
+  author = {Nishida, Harufumi},
+  date = {1989},
+  journaltitle = {Botanical Magazine Tokyo},
+  volume = {102},
+  pages = {255--282},
+  doi = {10.1007/BF02488568}
+}
+
+@article{Ogura-1927b,
+  title = {On the structure and affinities of some fossil tree-ferns from Japan},
+  author = {Ogura, Y},
+  date = {1927},
+  journaltitle = {Journal of the Faculty of Science, Imperial University of Tokyo},
+  volume = {1},
+  pages = {351--380}
+}
+
+@article{Ogura-1933,
+  title = {On the structure of a fossil fern stem of {\emph{Cibotium}}-type from the Upper Cretaceous of Iwate},
+  author = {Ogura, Yudzuru},
+  date = {1933},
+  journaltitle = {The Botanical Magazine},
+  volume = {48},
+  number = {563},
+  pages = {748--754},
+  doi = {10.15281/jplantres1887.47.748}
+}
+
+@article{Piel-1971,
+  title = {Palynology of Oligocene sediments from central British Columbia},
+  author = {Piel, K. M.},
+  date = {1971},
+  journaltitle = {Canadian Journal of Botany},
+  volume = {49},
+  pages = {1885--1920},
+  doi = {10.1139/b71-266}
 }
 
 @article{Pigg_etal-2021,
-  title={{Fossil Dennstaedtiaceae and Hymenophyllaceae from the Early Eocene of the Pacific Northwest}},
-  author={Pigg, Kathleen B and DeVore, Melanie L and Greenwood, David R and Sundue, Michael A and Schwartsburd, Pedro and Basinger, James F},
-  journal={International Journal of Plant Sciences},
-  volume={182},
-  number={9},
-  pages={793--807},
-  year={2021}
+  title = {Fossil Dennstaedtiaceae and Hymenophyllaceae from the Early Eocene of the Pacific Northwest},
+  author = {Pigg, Kathleen B and DeVore, Melanie L and Greenwood, David R and Sundue, Michael A and Schwartsburd, Pedro and Basinger, James F},
+  date = {2021},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {182},
+  number = {9},
+  pages = {793--807},
+  doi = {10.1086/715633}
+}
+
+@article{Pinson_etal-2018,
+  title = {\emph{Culcita remberi} sp. nov., an understory fern of Cyatheales from the Miocene of northern Idaho},
+  author = {Pinson, Jerald B. and Manchester, Steven R. and Sessa, Emily B.},
+  date = {2018},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {179},
+  number = {8},
+  pages = {635--639},
+  doi = {10.1086/698938}
+}
+
+@article{Poinar_Buckley-2008,
+  title = {\emph{Cretacifilix fungiformis} gen. and sp. nov., an eupolypod fern (Polypodiales) in early Cretaceous Burmese Amber},
+  author = {Poinar Jr., George O. and Buckley, Ron},
+  date = {2008},
+  journaltitle = {Journal of the Botanical Research Institute of Texas},
+  pages = {1175--1182}
+}
+
+@article{PteridophytePhylogenyGroupI2016,
+  title = {A community-derived classification for extant lycophytes and ferns},
+  author = {{Pteridophyte Phylogeny Group I}},
+  date = {2016},
+  journaltitle = {Journal of Systematics and Evolution},
+  volume = {54},
+  number = {6},
+  pages = {563--603},
+  doi = {10.1111/jse.12229}
+}
+
+@article{Rees_Cleal-2004,
+  title = {Lower Jurassic floras from Hope Bay and Botany Bay, Antarctica},
+  author = {Rees, P.M. and Cleal, C.J.},
+  date = {2004},
+  journaltitle = {Special Papers in Palaentology},
+  volume = {72},
+  pages = {5--90}
+}
+
+@article{Regalado_etal-2017,
+  title = {The first fossil of Lindsaeaceae (Polypodiales) from the Cretaceous amber forest of Myanmar},
+  author = {Regalado, Ledis and Schmidt, Alexander R and Müller, Patrick and Kobbert, Max J and Schneider, Harald and Heinrichs, Jochen},
+  date = {2017},
+  journaltitle = {Cretaceous Research},
+  volume = {72},
+  pages = {8--12},
+  doi = {10.1016/j.cretres.2016.12.003}
+}
+
+@article{Regalado_etal-2017b,
+  title = {A fossil species of the enigmatic early polypod fern genus {\emph{Cystodium}} (Cystodiaceae) in Cretaceous amber from Myanmar},
+  author = {Regalado, Ledis and Schmidt, Alexander R and Appelhans, Marc S and Ilsemann, Bork},
+  date = {2017},
+  journaltitle = {Scientific Reports},
+  volume = {7},
+  number = {14615},
+  pages = {1--9}
+}
+
+@article{Regalado_etal-2018,
+  title = {Fossil evidence of eupolypod ferns in the mid-Cretaceous of Myanmar},
+  author = {Regalado, Ledis and Schmidt, Alexander R and Krings, Michael and Bechteler, Julia and Schneider, Harald and Heinrichs, Jochen},
+  date = {2018},
+  journaltitle = {Plant Systematics and Evolution},
+  volume = {304},
+  number = {1},
+  pages = {1--13},
+  doi = {10.1007/s00606-017-1439-2}
+}
+
+@article{Regalado_etal-2019,
+  title = {\emph{Heinrichsia cheilanthoides} gen. et sp. nov., a fossil fern in the family Pteridaceae (Polypodiales) from the Cretaceous amber forests of Myanmar},
+  author = {Regalado, Ledis and Schmidt, Alexander R and Müller, Patrick and Niedermeier, Lisa and Krings, Michael and Schneider, Harald},
+  date = {2019},
+  journaltitle = {Journal of Systematics and Evolution},
+  volume = {57},
+  number = {4},
+  pages = {329--338},
+  doi = {10.1111/jse.12514}
+}
+
+@article{Ren_etal-2022,
+  title = {New species of fossil {\emph{Dryopterites}} from the Lower Cretaceous in the Zhongkouzi Basin, Beishan area, Northwest China, and its geological significance},
+  author = {Ren, Wen-xiu and Wu, Guang-tao and Han, Lei and Hua, Yi-fan and Sun, Bai-nian},
+  date = {2022},
+  journaltitle = {Historical Biology},
+  pages = {1--8},
+  doi = {10.1080/08912963.2021.2022135}
+}
+
+@article{Rothwell_etal-2018,
+  title = {Resolving the overall pattern of marattialean fern phylogeny},
+  author = {Rothwell, Gar W and Millay, Michael A and Stockey, Ruth A},
+  date = {2018},
+  journaltitle = {American Journal of Botany},
+  volume = {105},
+  number = {8},
+  pages = {1304--1314},
+  doi = {10.1002/ajb2.1115}
+}
+
+@article{Rothwell_Stockey-1991,
+  title = {\emph{Onoclea sensibilis} in the Paleocene of North America, a dramatic example of structural and ecological stasis},
+  author = {Rothwell, Gar W. and Stockey, Ruth},
+  date = {1991},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {70},
+  pages = {113--124},
+  doi = {10.1016/0034-6667(91)90081-D}
+}
+
+@article{Schneider_etal-2016,
+  title = {Burmese amber fossils bridge the gap in the Cretaceous record of polypod ferns},
+  author = {Schneider, Harald and Schmidt, Alexander R and Heinrichs, Jochen},
+  date = {2016},
+  journaltitle = {Perspectives in Plant Ecology, Evolution and Systematics},
+  volume = {18},
+  pages = {70--78},
+  doi = {10.1016/j.ppees.2016.01.003}
+}
+
+@article{Schnneider_etal-2015,
+  title = {A new Dominican amber fossil of the derived fern genus {\emph{Pleopeltis}} confirms generic stasis in the epiphytic fern diversity of the West Indies},
+  author = {Schneider, Harald and Schmidt, Alexander R and Nascimbene, Paul C and Heinrichs, Jochen},
+  date = {2015},
+  journaltitle = {Organisms Diversity \& Evolution},
+  volume = {15},
+  pages = {277--283},
+  doi = {10.1007/s13127-015-0200-3}
+}
+
+@article{Scott_Galtier-1996,
+  title = {A review of the problems in the stratigraphical, palaeoecological and palaeobiogeographical interpretation of Lower Carboniferous (Dinantian) floras from Western Europe},
+  author = {Scott, Andrew C and Galtier, Jean},
+  date = {1996},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {90},
+  pages = {141--153},
+  doi = {10.1016/0034-6667(95)00028-3}
 }
 
 @article{Serbert_Rothwell-2006,
-  title={{Anatomically preserved ferns from the late Cretaceous of western North America. II. Blechnaceae/Dryopteridaceae}},
-  author={Serbet, Rudolph and Rothwell, Gar W},
-  journal={International Journal of Plant Sciences},
-  volume={167},
-  number={3},
-  pages={703--709},
-  year={2006}
+  title = {Anatomically preserved ferns from the late Cretaceous of western North America. II. Blechnaceae/Dryopteridaceae},
+  author = {Serbet, Rudolph and Rothwell, Gar W},
+  date = {2006},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {167},
+  number = {3},
+  pages = {703--709},
+  doi = {10.1086/500996}
 }
+
+@article{Skog-1976,
+  title = {\emph{Loxsomopteris anasilla}, a new fossil fern rhizome from the Cretaceous of Maryland},
+  author = {Skog, Judith E},
+  date = {1976},
+  journaltitle = {American Fern Journal},
+  volume = {66},
+  number = {1},
+  pages = {8--14},
+  doi = {10.2307/1546365}
+}
+
+@article{Smith_etal-2006,
+  title = {\emph{Trawetssia princetonensis} gen. et sp. nov. (Blechnaceae): a permineralized fern from the Middle Eocene Princeton Chert},
+  author = {Smith, Selena Y and Stockey, Ruth A and Nishida, Harufumi and Rothwell, Gar W},
+  date = {2006},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {167},
+  pages = {711--719},
+  doi = {10.1086/501034}
+}
+
+@article{Stockey_etal-1999,
+  title = {Permineralized ferns from the Middle Eocene Princeton Chert. I. {{{\emph{Makotopteris princetonensis}}}} gen. et sp. nov. (Athyriaceae)},
+  author = {Stockey, Ruth A and Nishida, Harufumi and Rothwell, Gar W},
+  date = {1999},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {160},
+  pages = {1047--1055},
+  doi = {10.1086/314191}
+}
+
+@article{Stockey_Rothwell-2004,
+  title = {Cretaceous tree ferns of western North America: {{{\emph{Rickwoodopteris hirsuta}}}} gen. et sp. nov. (Cyatheaceae s.l.)},
+  author = {Stockey, Ruth A and Rothwell, Gar W},
+  date = {2004},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {132},
+  pages = {103--114},
+  doi = {10.1016/j.revpalbo.2004.05.002}
+}
+
+@article{Su_etal-2011,
+  title = {A new {\emph{Drynaria}} (Polypodiaceae) from the Upper Pliocene of Southwest China},
+  author = {Su, Tao and Jacques, Frédéric M B and Liu, Yu-sheng Christopher and Xiang, Jianying and Xing, Yaowu and Huang, Yongjiang and Zhou, Zhekun},
+  date = {2011},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {164},
+  pages = {132--142},
+  doi = {10.1016/j.revpalbo.2010.11.011}
+}
+
+@article{Taylor-1967,
+  title = {On the structure and phylogenetic relationships of the fern {\emph{Radstockia}} Kidston},
+  author = {Taylor, Thomas N},
+  date = {1967},
+  journaltitle = {Palaeontology},
+  volume = {10},
+  pages = {43--46}
+}
+
+@article{Tian_etal-2018,
+  title = {Permineralized osmundaceous and gleicheniaceous ferns from the Jurassic of Inner Mongolia, NE China},
+  author = {Tian, Ning and Wang, Yong-dong and Zhang, Wu and Zheng, Shao-lin and Zhu, Zhi-peng},
+  date = {2018},
+  journaltitle = {Palaeobiodiversity and Palaeoenvironments},
+  volume = {98},
+  pages = {165--176},
+  doi = {10.1007/s12549-017-0313-0}
+}
+
+@article{Tidwell_etal-1989,
+  title = {\emph{Oguracaulis banksii} gen. et sp. nov., a mid-Mesozoic tree-fern stem from Tasmania, Australia},
+  author = {Tidwell, William D and Nishida, Harufumi and Webster, Neri},
+  date = {1989},
+  journaltitle = {Papers and Proceedings of the Royal Society of Tasmania},
+  volume = {123},
+  pages = {15--25},
+  doi = {10.26749/rstpp.123.15}
+}
+
+@book{Traverse_Ames-1979,
+  title = {Catalog of fossil spores and pollen (Volume 41): Late Cretaceous and Early Tertiary spores and pollen from the USA and the USSR},
+  author = {Traverse, A. and Ames, H. T.},
+  date = {1979},
+  volume = {41},
+  pages = {1--210},
+  publisher = {The Pennsylvania State University}
+}
+
+@inproceedings{Upchurch_Mack-1998,
+  title = {Latest Cretaceous leaf megafloras from the Jose Creek Member, McRae Formation of New Mexico},
+  booktitle = {Las Cruces Country II},
+  author = {Upchurch Jr., Garland R and Mack, Greg H.},
+  editor = {Mack, Greg H. and Austin, G.S. and Barker, J. M.},
+  date = {1998},
+  pages = {209--222},
+  publisher = {New Mexico Geological Society Guidebook, 49th Field Conference}
+}
+
+@article{vanKonijnenburg-1989,
+  title = {Dicksoniaceous spores in situ from the Jurassic of Yorshire, England},
+  author = {van Konijnenburg-van Cittert, J. H.A.},
+  options = {useprefix=true},
+  date = {1989},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {61},
+  pages = {273--301},
+  doi = {10.1016/0034-6667(89)90035-3}
+}
+
+@article{VanUffelen-1991,
+  title = {Fossil Polypodiaceae and their spores},
+  author = {Uffelen, Gerda A},
+  date = {1991},
+  journaltitle = {Blumea: Biodiversity, Evolution and Biogeography of Plants},
+  volume = {36},
+  number = {1},
+  pages = {253--272}
+}
+
+@article{Vikulin_etal-1987,
+  title = {A new fossil genus {\emph{Prodrynaria}} (Polypodiaceae) from the Paleogene flora of Tim (tbe south of the middle Russian upland)},
+  author = {Vikulin, Sergei V.},
+  date = {1982},
+  journaltitle = {Botanicheskii Zhurnal},
+  volume = {72},
+  pages = {1--7}
+}
+
+@article{Wang_Pfefferkorn-2008,
+  title = {\emph{Marattia aganzhensis} sp. nov. from the Lower Jurassic Daxigou Formation of Lanzhou, Gansu, China},
+  author = {Yang, Shu and Wang, Jun and Pfefferkorn, Hermann W},
+  date = {2008},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {169},
+  number = {3},
+  pages = {473--482},
+  doi = {10.1086/526458}
+}
+
+@article{Xie_etal-2016,
+  title = {First megafossil record of {\emph{Neolepisorus}} (Polypodiaceae) from the late Miocene of Yunnan, Southwest China},
+  author = {Xie, Sanping and Li, Binke and Zhang, Sihang and Shao, Yang and Wu, Jingyu and Sun, Bainian},
+  date = {2016},
+  journaltitle = {PalZ},
+  volume = {90},
+  number = {2},
+  pages = {413--423},
+  doi = {10.1007/s12542-016-0304-x}
+}
+
+@article{Xu_etal-2017,
+  title = {The first megafossil record of {\emph{Goniophlebium}} (Polypodiaceae) from the Middle Miocene of Asia and its paleoecological implications},
+  author = {Xu, Cong-li and Huang, Jian and Su, Tao and Zhang, Xian-chun and Li, Shu-feng and Zhou, Zhe-kun},
+  date = {2017},
+  journaltitle = {Palaeoworld},
+  volume = {26},
+  number = {3},
+  pages = {543--552},
+  doi = {10.1016/j.palwor.2017.01.006}
+}
+
+@article{Xu_etal-2017b,
+  title = {\emph{Asplenium sanshuiense} sp. nov.: The lowest latitude fossil record of the genus},
+  author = {Xu, Kewag and Liao, Wenbo and Jin, Jianhua and Liu, Xiaoyan},
+  date = {2017},
+  journaltitle = {Acta Geologica Sinica},
+  volume = {91},
+  number = {4},
+  pages = {1179--1189},
+  doi = {10.1111/1755-6724.13353}
+}
+
+@article{Yamada_Kato-2002,
+  title = {\emph{Regnellites nagashimae} gen. et sp. nov., the oldest macrofossil of Marsileaecae, from the Upper Jurassic to Lower Cretaceous of Western Japan},
+  author = {Yamada, Toshihiro and Kato, Masahiro},
+  date = {2002},
+  journaltitle = {International Journal of Plant Sciences},
+  volume = {163},
+  number = {5},
+  pages = {715--723},
+  doi = {10.1086/342036}
+}
+
+@article{Yang_etal-2016,
+  title = {A new species of {\emph{Drynaria}} (Polypodiaceae) from the late Miocene of Yunnan, Southwest China and implications on the genus evolution},
+  author = {Yu, Yang and Xie, San-ping and Devaney, John and Zhang, Si-hang and Chen, Tian-yu},
+  date = {2020},
+  journaltitle = {Palaeobiodiversity and Palaeoenvironments},
+  volume = {100},
+  pages = {939--949},
+  doi = {10.1007/s12549-020-00429-0}
+}
+
+@article{Zhao2019,
+  title = {Backbone phylogeny of {\emph{Lepisorus}} (Polypodiaceae) and a novel infrageneric classification based on the total evidence from plastid and morphological data},
+  author = {Zhao, Cun-Feng and Wei, Ran and Zhang, Xian-Chun and Xiang, Qiao-Ping},
+  date = {2020},
+  journaltitle = {Cladistics},
+  shortjournal = {Cladistics},
+  volume = {36},
+  number = {3},
+  pages = {235--258},
+  doi = {10.1111/cla.12403}
+}
+
+@article{Zhaogi_Taylor-1988,
+  title = {On a new Gleicheniaceous fern from the Permian of South China},
+  author = {Zhaoqi, Yao and Taylor, Thomas N},
+  date = {1988},
+  journaltitle = {Review of Palaeobotany and Palynology},
+  volume = {54},
+  pages = {121--134},
+  doi = {10.1016/0034-6667(88)90008-5}
+}
+
+


### PR DESCRIPTION
Zotero has some nice features for maintaining bibliographies, such as automatic adding of DOIs (notice DOIs have been added!).

I created a Zotero group with the ferncal bibliography: https://www.zotero.org/groups/4739261/ferncal

The library can be exported to biblatex format using the [Better BibTex for Zotero](https://retorque.re/zotero-better-bibtex/) plugin.

I have the export set up to run automatically on my machine, so any edits made in Zotero will automatically show up in the bib file.

Export settings include:
- Format: Better BibLaTeX
- Export unicode as plain-text latex commands: false
- Use BibLaTeX extended name format: false
- Export notes: false
- Use journal abbreviations: false
- Export all child collections: false
- Extract JSTOR/Google Books/PubMed info from the URl into eprint fields: true
- Export language as: langid
- When item has both DOI and URL export: both
- Fields to omit from export: abstract, month, file, issn, library catalog, extra, keywords
- Include JabRef-specific metadata: no
- Automatically abbreviate journal title: false
- Include comments about potential problems with the exported entries: true
- Include automatic tags in export: true
- When converting to plain-text latex commands: Minimize the number of switches between math-mode and text-mode
- Apply title-casing to titles: false
- Apply case-protection to capitalized words by enclosing them in braces: false
